### PR TITLE
Rules-based medicinal chemist critic (Halluminate sub-theme)

### DIFF
--- a/colab/train_pharmarl.ipynb
+++ b/colab/train_pharmarl.ipynb
@@ -470,6 +470,65 @@
     "    mean, std = schema_drift_rollout(profile)\n",
     "    print(f'  {profile:15s}: mean cumulative = {mean:+.3f} +/- {std:.3f}')\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 12. Multi-actor critic demo (Halluminate sub-theme)\n",
+    "\n",
+    "Demonstrates the **rules-based medicinal chemist critic** \u2014 a separate logical agent that examines each post-edit molecule and emits structured feedback (PAINS substructures, Lipinski warnings, reactive group flags). The policy can choose to revise (REMOVE_FRAGMENT / SUBSTITUTE_ATOM) on its next turn or proceed.\n",
+    "\n",
+    "Why rules-based instead of an LLM critic? **Deterministic** (same input -> same critique, reproducible critic-conditioned training) and **ms latency** (no rollout slowdown, no API cost). The env contract has a clean seam \u2014 a frozen LLM critic can be swapped in here as future work.\n",
+    "\n",
+    "Default OFF \u2014 enable with `CurriculumConfig(critic_enabled=True)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Critic-agent demo \u2014 runs in-process, no env server required.\n",
+    "import sys\n",
+    "sys.path.insert(0, '/content/pharmarl')  # adjust to your local clone path\n",
+    "\n",
+    "import random\n",
+    "from models import MoleculeAction\n",
+    "from server.curriculum import CurriculumConfig\n",
+    "from server.drug_discovery_environment import DrugDiscoveryEnvironment\n",
+    "\n",
+    "# Critic enabled \u2014 observation.metadata.critique populated each step.\n",
+    "config = CurriculumConfig(critic_enabled=True)\n",
+    "env = DrugDiscoveryEnvironment(seed=7, config=config)\n",
+    "obs = env.reset(difficulty='easy')\n",
+    "print(f'Start molecule: {obs.smiles}')\n",
+    "print('-' * 60)\n",
+    "\n",
+    "rng = random.Random(7)\n",
+    "for step_i in range(10):\n",
+    "    # Random rollout \u2014 pick any fragment from the vocab.\n",
+    "    fragment = rng.choice(obs.available_fragments)\n",
+    "    action = MoleculeAction(action_type='ADD_FRAGMENT', fragment=fragment, position=0)\n",
+    "    obs = env.step(action)\n",
+    "\n",
+    "    crit = obs.metadata.get('critique', {})\n",
+    "    summary = crit.get('summary', '(no critique \u2014 action invalid)')\n",
+    "    issue_codes = [i['code'] for i in crit.get('issues', [])]\n",
+    "    print(f'step {step_i + 1}: ADD({fragment:>15s}) -> {obs.smiles}')\n",
+    "    print(f'         {summary}  codes={issue_codes}')\n",
+    "    if obs.done:\n",
+    "        break\n",
+    "\n",
+    "# Example output (illustrative):\n",
+    "#   step 1: ADD(            c1ccccc1) -> ... -> Critic says: approve. 0 issues. codes=[]\n",
+    "#   step 2: ADD(             C(=S)N) -> ... -> Critic says: revise. 1 issues. codes=['PAINS_THIOCARBONYL_NUISANCE']\n",
+    "#   step 3: REMOVE_FRAGMENT (agent revised based on critique) -> Critic says: approve.\n",
+    "#\n",
+    "# In production, the policy reads obs.metadata['critique']['summary'] in its prompt and\n",
+    "# decides whether to revise. With critic_enabled=False (default), this metadata key is absent.\n"
+   ]
   }
  ],
  "metadata": {

--- a/docs/qa-defense.md
+++ b/docs/qa-defense.md
@@ -126,6 +126,16 @@ Don't pretend this is a "novel disease" test. It's a novel *target* in the same 
 
 ---
 
+## Q17. Why a rules-based critic instead of an LLM critic?
+
+**"Two reasons. First, deterministic: same molecule always gets the same critique, which makes critic-conditioned training reproducible. An LLM critic introduces stochasticity that interferes with reward signal cleanliness. Second, fast: the rules engine returns in milliseconds — an LLM critic would 10x rollout latency. The Halluminate sub-theme rewards multi-actor environments; what matters is that there's a separate logical agent providing feedback that the policy can integrate, not that the agent is itself an LLM. Future work could swap in a frozen LLM critic for richer feedback."**
+
+If pressed on what the critic actually checks: **"PAINS substructures (thiocarbonyl, rhodanine, nitroaromatic Michael acceptors), Lipinski-flavored property warnings (MW > 500, LogP > 5), reactive group flags (alkyl halide, epoxide, anhydride), and a heavy-atom sanity floor. Verdict is `approve` / `revise` / `reject`; the critique is appended to the next observation's metadata under `critique` so the policy can choose to revise via REMOVE_FRAGMENT or SUBSTITUTE_ATOM."**
+
+If asked why it's gated behind `critic_enabled` and default OFF: **"The headline training run targets the Reward Improvement curve on DRD2 — that's our insurance criterion. The critic adds an extra observation field, which would change the prompt distribution for the policy. We isolate it behind a flag so the headline run is reproducible against an LLM-only baseline; the critic-on run is the multi-actor demo."**
+
+---
+
 ## What NOT to say
 
 - ❌ "AI to cure all diseases" / "any and all disease"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,11 @@ server = "pharmarl.server.app:main"
 include-package-data = true
 packages = ["pharmarl", "pharmarl.server", "pharmarl.server.molecule_engine", "pharmarl.server.oracles"]
 package-dir = { "pharmarl" = ".", "pharmarl.server" = "server", "pharmarl.server.molecule_engine" = "server/molecule_engine", "pharmarl.server.oracles" = "server/oracles" }
+
+[tool.pytest.ini_options]
+# Without --confcutdir=tests, pytest walks up from tests/__init__.py and tries to import
+# the project-root __init__.py (which uses relative imports and fails under direct
+# script-style execution). Setting confcutdir confines collection to tests/.
+testpaths = ["tests"]
+addopts = "--confcutdir=tests"
+norecursedirs = [".git", ".venv", "build", "dist", "server", "scripts", "examples", "colab", "docs"]

--- a/server/critic.py
+++ b/server/critic.py
@@ -1,0 +1,155 @@
+"""Rules-based medicinal chemist critic.
+
+After the agent edits a molecule, the critic examines the result and emits
+a structured critique. Hits the Halluminate "multi-actor" sub-theme without
+the cost/latency of a real LLM call.
+
+The critic is a DETERMINISTIC rules engine — same input always gives the
+same critique. That's intentional: it makes critic-conditioned training
+reproducible and the critic itself non-gameable in a stochastic sense.
+
+Design notes:
+  - Each rule is a SMARTS substructure search OR an RDKit Descriptors check.
+  - Issues are tagged with a stable code (e.g. PAINS_THIOCARBONYL_NUISANCE) so
+    the policy can learn to recognize and respond to specific critique types.
+  - Verdict: 'reject' on hard error, 'revise' on >=2 warnings, else 'approve'.
+  - Latency: ms-scale, no I/O, fully in-process. Future work could swap in a
+    frozen LLM critic at this seam without changing the env contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from rdkit import Chem
+from rdkit.Chem import Descriptors
+
+
+@dataclass
+class CritiqueIssue:
+    severity: str   # "warning" | "error" | "info"
+    code: str       # e.g. "PAINS_THIOCARBONYL_NUISANCE", "MW_TOO_HIGH"
+    message: str    # human-readable explanation
+
+
+@dataclass
+class Critique:
+    smiles: str
+    issues: List[CritiqueIssue] = field(default_factory=list)
+    overall: str = "approve"   # "approve" | "revise" | "reject"
+
+
+# Substructure SMARTS for known PAINS / nuisance moieties.
+# Extend this catalog as the curriculum encounters new failure modes.
+_KNOWN_PAINS_SMARTS: Dict[str, str] = {
+    "thiocarbonyl_nuisance": "C(=S)",                       # known assay interference
+    "rhodanine_core": "C1SC(=N1)NC=O",                      # PAINS rhodanine
+    "michael_acceptor_nitroaromatic": "[N+](=O)[O-]",       # nitro group, often reactive
+}
+
+
+# Reactive / metabolically labile groups — flagged as "info", not "warning",
+# because some are tolerable in a hit-finding context but worth surfacing.
+_REACTIVE_GROUPS: Dict[str, str] = {
+    "alkyl_halide": "[CX4][F,Cl,Br,I]",
+    "epoxide": "C1CO1",
+    "anhydride": "C(=O)OC(=O)",
+}
+
+
+class MedChemCritic:
+    """Rules-based reviewer. Inspects a molecule and returns structured critique.
+
+    A separate logical agent that runs after the policy proposes an edit. The
+    env appends the critique to the next observation; the policy can choose to
+    revise (REMOVE_FRAGMENT / SUBSTITUTE_ATOM) or proceed.
+    """
+
+    def critique(self, smiles: str) -> Critique:
+        mol = Chem.MolFromSmiles(smiles) if smiles else None
+        if mol is None or mol.GetNumAtoms() == 0:
+            return Critique(
+                smiles=smiles,
+                issues=[CritiqueIssue("error", "INVALID", "Could not parse molecule")],
+                overall="reject",
+            )
+
+        issues: List[CritiqueIssue] = []
+
+        # ── Lipinski-flavored property checks ──────────────────────────────
+        mw = Descriptors.MolWt(mol)
+        logp = Descriptors.MolLogP(mol)
+        if mw > 500:
+            issues.append(CritiqueIssue(
+                "warning", "MW_TOO_HIGH",
+                f"MW={mw:.1f} > 500 — Lipinski violation, oral bioavailability concern",
+            ))
+        if logp > 5:
+            issues.append(CritiqueIssue(
+                "warning", "LOGP_TOO_HIGH",
+                f"LogP={logp:.2f} > 5 — likely poor solubility",
+            ))
+
+        # ── PAINS substructure flags ───────────────────────────────────────
+        for code, smarts in _KNOWN_PAINS_SMARTS.items():
+            patt = Chem.MolFromSmarts(smarts)
+            if patt is not None and mol.HasSubstructMatch(patt):
+                issues.append(CritiqueIssue(
+                    "warning", f"PAINS_{code.upper()}",
+                    f"Contains pattern {code} — known assay interference / nuisance",
+                ))
+
+        # ── Reactive group flags (info, not warning) ───────────────────────
+        for code, smarts in _REACTIVE_GROUPS.items():
+            patt = Chem.MolFromSmarts(smarts)
+            if patt is not None and mol.HasSubstructMatch(patt):
+                issues.append(CritiqueIssue(
+                    "info", f"REACTIVE_{code.upper()}",
+                    f"Contains {code} — be aware of reactivity / metabolic liability",
+                ))
+
+        # ── Heavy-atom sanity ──────────────────────────────────────────────
+        n_heavy = mol.GetNumHeavyAtoms()
+        if n_heavy < 5:
+            issues.append(CritiqueIssue(
+                "info", "TOO_SMALL",
+                f"Only {n_heavy} heavy atoms — likely too small for selective binding",
+            ))
+
+        # ── Verdict ────────────────────────────────────────────────────────
+        n_errors = sum(1 for i in issues if i.severity == "error")
+        n_warnings = sum(1 for i in issues if i.severity == "warning")
+        if n_errors > 0:
+            overall = "reject"
+        elif n_warnings >= 2:
+            overall = "revise"
+        else:
+            overall = "approve"
+
+        return Critique(smiles=smiles, issues=issues, overall=overall)
+
+
+# Singleton — env imports this instance to avoid re-instantiation per step.
+default_critic = MedChemCritic()
+
+
+def critique_to_dict(c: Critique) -> Dict[str, object]:
+    """Serialize a Critique into a dict suitable for observation.metadata."""
+    return {
+        "overall": c.overall,
+        "issues": [
+            {"severity": i.severity, "code": i.code, "message": i.message}
+            for i in c.issues
+        ],
+        "summary": f"Critic says: {c.overall}. {len(c.issues)} issues flagged.",
+    }
+
+
+__all__ = [
+    "CritiqueIssue",
+    "Critique",
+    "MedChemCritic",
+    "default_critic",
+    "critique_to_dict",
+]

--- a/server/curriculum.py
+++ b/server/curriculum.py
@@ -62,6 +62,13 @@ class CurriculumConfig:
     weights_late_potency_pre: tuple = (0.10, 0.40, 0.30, 0.20)     # drug-like + ADMET focus
     weights_late_potency_post: tuple = (0.45, 0.20, 0.20, 0.15)    # potency now matters
 
+    # ─── Multi-actor critic (Halluminate sub-theme) ────────────────────────
+    # Rules-based medicinal-chemist critic inspects each post-edit molecule
+    # and the critique is appended to the next observation's metadata. The
+    # agent can integrate or ignore the feedback. Default OFF so the headline
+    # training run is unaffected.
+    critic_enabled: bool = False                        # MASTER FLAG, default OFF
+
 
 DEFAULT_CONFIG = CurriculumConfig()
 

--- a/server/drug_discovery_environment.py
+++ b/server/drug_discovery_environment.py
@@ -36,6 +36,7 @@ except ImportError:
     )
 
 try:
+    from .critic import critique_to_dict, default_critic
     from .curriculum import (
         CurriculumConfig,
         DEFAULT_CONFIG,
@@ -68,6 +69,7 @@ try:
     )
     from .scenarios import sample_starting_molecule
 except ImportError:
+    from server.critic import critique_to_dict, default_critic  # type: ignore
     from server.curriculum import (  # type: ignore
         CurriculumConfig,
         DEFAULT_CONFIG,
@@ -422,6 +424,23 @@ class DrugDiscoveryEnvironment(Environment):
         active_constraints = self._active_constraints(weights_now)
         drift_warning = self._drift_warning(weights_now, weights_prev)
 
+        metadata: dict = {
+            "cumulative_reward": self._state.cumulative_reward,
+            "final_oracle_scores": self._final_oracle_scores,
+            "drift_profile": self._state.drift_profile,
+            "drift_step": self._state.drift_step,
+            "weights": list(weights_now),
+        }
+
+        # Multi-actor critic (Halluminate sub-theme). Default OFF — gated by
+        # config.critic_enabled. When ON, a separate logical agent (the
+        # rules-based medicinal-chemist critic) inspects the current molecule
+        # and emits structured feedback that the policy can integrate or ignore
+        # on its next turn (via REMOVE_FRAGMENT / SUBSTITUTE_ATOM).
+        if self._config.critic_enabled and last_action_valid and self._state.smiles:
+            critique = default_critic.critique(self._state.smiles)
+            metadata["critique"] = critique_to_dict(critique)
+
         return MoleculeObservation(
             smiles=self._state.smiles,
             selfies=self._state.selfies,
@@ -438,11 +457,5 @@ class DrugDiscoveryEnvironment(Environment):
             reward=float(reward),
             active_constraints=active_constraints,
             drift_warning=drift_warning,
-            metadata={
-                "cumulative_reward": self._state.cumulative_reward,
-                "final_oracle_scores": self._final_oracle_scores,
-                "drift_profile": self._state.drift_profile,
-                "drift_step": self._state.drift_step,
-                "weights": list(weights_now),
-            },
+            metadata=metadata,
         )

--- a/tests/test_critic.py
+++ b/tests/test_critic.py
@@ -1,0 +1,116 @@
+"""Tests for the rules-based medicinal-chemist critic (Halluminate sub-theme).
+
+The critic is a deterministic substructure / property reviewer that runs after
+the policy proposes an edit. These tests cover:
+
+  - invalid SMILES → reject verdict
+  - high-MW polyaromatic → MW_TOO_HIGH warning
+  - drug-like aspirin → approve (no warnings, no errors)
+  - thiocarbonyl-containing fragment → PAINS warning
+  - reproducibility / determinism (same input → same critique)
+  - critic disabled by default (env behavior unchanged)
+  - critic enabled → observation.metadata.critique populated
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from models import MoleculeAction
+from server.critic import Critique, MedChemCritic, default_critic
+from server.curriculum import CurriculumConfig
+from server.drug_discovery_environment import DrugDiscoveryEnvironment
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Critic unit tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_critic_rejects_invalid_smiles() -> None:
+    """Garbled SMILES that won't parse should yield a 'reject' verdict."""
+    c = default_critic.critique("@@@invalid@@@")
+    assert c.overall == "reject"
+    assert any(i.severity == "error" and i.code == "INVALID" for i in c.issues)
+
+
+def test_critic_warns_about_high_mw() -> None:
+    """A large multi-amide blob (MW > 700) should trigger the MW_TOO_HIGH warning."""
+    big = (
+        "O=C(NCc1ccc(NC(=O)Nc2ccc(NC(=O)c3ccccc3)cc2)cc1)"
+        "c1ccc(NC(=O)Nc2ccc(NC(=O)c3ccccc3)cc2)cc1"
+    )
+    c = default_critic.critique(big)
+    codes = {i.code for i in c.issues}
+    assert "MW_TOO_HIGH" in codes
+
+
+def test_critic_approves_drug_like_molecule() -> None:
+    """Aspirin (CC(=O)Oc1ccccc1C(=O)O) is the canonical drug-like molecule.
+
+    No warnings, no errors → 'approve'.
+    """
+    c = default_critic.critique("CC(=O)Oc1ccccc1C(=O)O")
+    assert c.overall == "approve"
+    assert all(i.severity != "warning" for i in c.issues)
+
+
+def test_critic_flags_pains_pattern() -> None:
+    """A thiocarbonyl-containing molecule triggers the PAINS_THIOCARBONYL warning."""
+    c = default_critic.critique("CC(=S)NC")
+    codes = {i.code for i in c.issues}
+    assert any(code.startswith("PAINS_") for code in codes), (
+        f"expected at least one PAINS_* code, got {codes}"
+    )
+
+
+def test_critic_is_deterministic() -> None:
+    """Same SMILES → same critique. Crucial for reproducible critic-conditioned training."""
+    smi = "CC(=O)Oc1ccccc1C(=O)O"
+    a = default_critic.critique(smi)
+    b = default_critic.critique(smi)
+    assert a.overall == b.overall
+    assert [(i.code, i.severity) for i in a.issues] == [(i.code, i.severity) for i in b.issues]
+
+
+def test_critic_too_small_flag() -> None:
+    """Methane has too few heavy atoms — surface a TOO_SMALL info issue."""
+    c = default_critic.critique("C")
+    codes = {i.code for i in c.issues}
+    assert "TOO_SMALL" in codes
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Env-integration tests — critic is gated behind config.critic_enabled
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_critic_disabled_by_default() -> None:
+    """Without critic_enabled flag, observation.metadata has no 'critique' key.
+
+    Default OFF — the headline training run is unaffected.
+    """
+    env = DrugDiscoveryEnvironment(seed=42)  # default config → critic_enabled=False
+    env.reset(difficulty="trivial")
+    obs = env.step(MoleculeAction(action_type="ADD_FRAGMENT", fragment="C", position=0))
+    assert "critique" not in obs.metadata
+
+
+def test_critic_enabled_populates_observation() -> None:
+    """When critic_enabled=True, observation.metadata.critique is populated."""
+    config = CurriculumConfig(critic_enabled=True)
+    env = DrugDiscoveryEnvironment(seed=42, config=config)
+    env.reset(difficulty="trivial")
+    obs = env.step(MoleculeAction(action_type="ADD_FRAGMENT", fragment="C", position=0))
+    assert "critique" in obs.metadata
+    critique = obs.metadata["critique"]
+    assert "overall" in critique
+    assert critique["overall"] in ("approve", "revise", "reject")
+    assert "issues" in critique
+    assert "summary" in critique
+    assert critique["summary"].startswith("Critic says:")


### PR DESCRIPTION
## What

A deterministic rules-based "medicinal chemist" critic that examines each post-edit molecule and emits structured feedback (PAINS detection, MW/LogP warnings, reactive group flags). Gated behind `critic_enabled` flag (default OFF).

## Why

Halluminate sub-theme bonus prize: "multi-actor environments where an agent interacts with and manages multiple actors." The critic is a separate logical agent that the policy must consider when choosing edits.

## Why rules-based, not LLM

- Deterministic (reproducible critic-conditioned training)
- ms latency (no rollout slowdown)
- No API cost
- Can be swapped for a frozen LLM critic as future work — the env contract has a clean seam

## How

- `server/critic.py` — `MedChemCritic` class with PAINS catalog, Lipinski-flavored property checks, reactive group SMARTS
- `server/curriculum.py` — new `CurriculumConfig.critic_enabled` flag (default `False`)
- `server/drug_discovery_environment.py` — `_build_observation` injects `critique` into `metadata` when the flag is on and the last action was valid
- `tests/test_critic.py` — 8 new tests (unit + env integration)
- `colab/train_pharmarl.ipynb` — appended Section 11 with a 10-step random rollout demo
- `docs/qa-defense.md` — Q17 covering critic design choices
- `pyproject.toml` — `[tool.pytest.ini_options]` block fixing the project-root `__init__.py` collection issue so the canonical `pytest tests/ -v` gate passes

## Critic checks

- **PAINS substructures**: thiocarbonyl nuisance, rhodanine core, nitroaromatic Michael acceptor
- **Property warnings**: `MW > 500`, `LogP > 5`
- **Reactive group flags** (info): alkyl halide, epoxide, anhydride
- **Heavy-atom floor**: `< 5 atoms` flagged as `TOO_SMALL`
- **Verdict**: `reject` on parse error, `revise` on >=2 warnings, else `approve`

## Tests

- 8 new tests in `test_critic.py`: invalid SMILES rejection, high-MW warning, drug-like approval, PAINS pattern flag, determinism, too-small flag, critic-disabled-by-default, critic-enabled populates observation
- Total: 38 passing (30 existing + 8 new), validated via `pytest tests/ -v` and `python scripts/validate_stack.py`

## Safety

Default OFF. `critic_enabled=False` produces an observation with no `critique` key in `metadata`, identical behavior to current `main`. Sahil's headline training run is unaffected.

Closes part of #4.